### PR TITLE
FIX: Unable to download mongo and postgres jars

### DIFF
--- a/Dockerfile.spark
+++ b/Dockerfile.spark
@@ -6,5 +6,5 @@ RUN apt-get update && \
     apt-get clean
 
 USER 1001
-RUN wget -q -nc --no-check-certificate https://repo1.maven.org/maven2/org/mongodb/mongodb-jdbc/2.0.3/mongodb-jdbc-2.0.3-all.jar -P /opt/bitnami/spark/jars && \
-    wget -q -nc --no-check-certificate https://repo1.maven.org/maven2/org/postgresql/postgresql/42.6.0/postgresql-42.6.0.jar -P /opt/bitnami/spark/jars
+RUN wget -q -nc https://repo1.maven.org/maven2/org/mongodb/mongodb-jdbc/2.0.3/mongodb-jdbc-2.0.3-all.jar -P /opt/bitnami/spark/jars && \
+    wget -q -nc https://repo1.maven.org/maven2/org/postgresql/postgresql/42.6.0/postgresql-42.6.0.jar -P /opt/bitnami/spark/jars


### PR DESCRIPTION
--no-check-certificate flag on wget causes failure on dowload of mongodb-jdbc-2.0.3-all.jar and postgresql-42.6.0.jar